### PR TITLE
PageHeader, SiteTopUpper のリファクタリングと翻訳に関する注釈の追加

### DIFF
--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -1,47 +1,120 @@
 <template>
-  <div class="header">
-    <h2 class="pageTitle">
+  <div class="PageHeader mb-3">
+    <h2 class="PageTitle">
       <v-icon v-if="iconPath" size="4rem" class="mr-2">
         {{ iconPath }}
       </v-icon>
-      <slot />
+      {{ title }}
     </h2>
+    <div v-if="updatedAt" class="UpdatedAt">
+      <span>{{ $t('最終更新') }}</span>
+      <time :datetime="convertDate(updatedAt)">{{
+        formatDate(updatedAtAsDate)
+      }}</time>
+    </div>
+    <div v-show="!['ja', 'ja-basic'].includes($i18n.locale)" class="Annotation">
+      <span>{{ $t('注釈') }}</span>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
 
-export default Vue.extend({
+import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
+
+type Data = {}
+type Methods = {
+  formatDate(date: Date): string
+  convertDate(dateAsString: string): string
+}
+type Computed = {
+  updatedAtAsDate: Date
+}
+type Props = {
+  iconPath: string
+  title: string
+  updatedAt: string
+}
+
+export default Vue.extend<Data, Methods, Computed, Props>({
   props: {
     iconPath: {
       type: String,
       required: false,
       default: '',
     },
+    title: {
+      type: String,
+      required: true,
+      default: '',
+    },
+    updatedAt: {
+      type: String,
+      required: true,
+      default: '',
+    },
+  },
+  computed: {
+    updatedAtAsDate() {
+      return new Date(this.updatedAt)
+    },
+  },
+  methods: {
+    formatDate(date) {
+      return `${this.$d(date, 'dateTime')} JST`
+    },
+    convertDate(dateAsString) {
+      return convertDatetimeToISO8601Format(dateAsString)
+    },
   },
 })
 </script>
 
 <style lang="scss" scoped>
-.header {
+.PageHeader {
   display: flex;
   align-items: flex-end;
   flex-wrap: wrap;
-}
-
-.pageTitle {
-  @include font-size(30);
-
-  color: $gray-2;
-  display: flex;
-  align-items: center;
-  line-height: 1.35;
-  font-weight: normal;
-  margin: 0 0.5em 0 0;
 
   @include lessThan($small) {
-    @include font-size(20);
+    flex-direction: column;
+    align-items: baseline;
+  }
+
+  .PageTitle {
+    @include font-size(30);
+
+    color: $gray-2;
+    display: flex;
+    align-items: center;
+    line-height: 1.35;
+    font-weight: normal;
+
+    @include lessThan($small) {
+      @include font-size(20);
+    }
+
+    @include largerThan($small) {
+      margin-right: 0.5em;
+    }
+  }
+
+  .UpdatedAt {
+    @include font-size(14);
+
+    color: $gray-3;
+
+    @include largerThan($small) {
+      margin-bottom: 0.2em;
+    }
+  }
+
+  .Annotation {
+    @include font-size(12);
+
+    color: $gray-3;
+    margin: 0.2em 0 0 auto;
   }
 }
 </style>

--- a/components/SiteTopUpper.vue
+++ b/components/SiteTopUpper.vue
@@ -1,23 +1,6 @@
 <template>
-  <div class="MainPage">
-    <div class="Header mb-3">
-      <page-header :icon-path="headerItem.iconPath">{{
-        headerItem.title
-      }}</page-header>
-      <div class="UpdatedAt">
-        <span>{{ $t('最終更新') }}</span>
-        <time :datetime="convertDate(lastUpdateAsString)">{{
-          formatDate(lastUpdate)
-        }}</time>
-      </div>
-      <div
-        v-show="!['ja', 'ja-basic'].includes($i18n.locale)"
-        class="Annotation"
-      >
-        <span>{{ $t('注釈') }}</span>
-      </div>
-    </div>
-    <whats-new class="mb-4" :items="newsItems" :is-emergency="true" />
+  <div class="SiteTopUpper">
+    <whats-new :items="newsItems" :is-emergency="true" />
     <detail-a />
     <detail-data />
     <VaccineInfoCard />
@@ -34,7 +17,6 @@
 </template>
 
 <script lang="ts">
-import { mdiChartTimelineVariant } from '@mdi/js'
 import Vue from 'vue'
 
 import DetailA from '@/components/DetailA.vue'
@@ -42,104 +24,33 @@ import DetailData from '@/components/DetailData.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import VaccineInfoCard from '@/components/VaccineInfoCard.vue'
 import WhatsNew from '@/components/WhatsNew.vue'
-import { Data as IData } from '@/libraries/auto_generated/data_converter/convertData'
 import {
   News as INews,
   NewsItem as INewsItem,
 } from '@/libraries/auto_generated/data_converter/convertNews'
-import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
 
-type Data = {
-  headerItem: {
-    iconPath: string
-    title: string
-  }
-}
-type Methods = {
-  formatDate(date: Date): string
-  convertDate(dateAsString: string): string
-}
+type Data = {}
+type Methods = {}
 type Computed = {
-  lastUpdate: Date
-  lastUpdateAsString: string
   newsItems: INewsItem[]
-  data: IData
   news: INews
 }
 type Props = {}
 
 export default Vue.extend<Data, Methods, Computed, Props>({
   components: {
-    PageHeader,
     WhatsNew,
     VaccineInfoCard,
     DetailData,
     DetailA,
   },
-  data() {
-    return {
-      headerItem: {
-        iconPath: mdiChartTimelineVariant,
-        title: this.$t('市内の最新感染動向') as string,
-      },
-      showStaticInfo: true,
-    }
-  },
   computed: {
-    lastUpdate() {
-      return new Date(this.lastUpdateAsString)
-    },
-    lastUpdateAsString() {
-      return this.data.lastUpdate
-    },
     newsItems() {
       return this.news.newsItems
-    },
-    data() {
-      return this.$store.state.data
     },
     news() {
       return this.$store.state.news
     },
   },
-  methods: {
-    formatDate(date) {
-      return `${this.$d(date, 'dateTime')} JST`
-    },
-    convertDate(dateAsString) {
-      return convertDatetimeToISO8601Format(dateAsString)
-    },
-  },
 })
 </script>
-
-<style lang="scss" scoped>
-.MainPage {
-  .Header {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-end;
-
-    @include lessThan($small) {
-      flex-direction: column;
-      align-items: baseline;
-    }
-  }
-
-  .UpdatedAt {
-    @include font-size(14);
-
-    color: $gray-3;
-    margin-bottom: 0.2rem;
-  }
-
-  .Annotation {
-    @include font-size(12);
-
-    color: $gray-3;
-    @include largerThan($small) {
-      margin: 0 0 0 auto;
-    }
-  }
-}
-</style>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="About">
-    <page-header class="mb-3">
-      {{ $t('当サイトについて') }}
-    </page-header>
+    <page-header :title="$t('当サイトについて')" />
     <static-card>
       {{
         $t(

--- a/pages/contacts.vue
+++ b/pages/contacts.vue
@@ -4,9 +4,7 @@
     aria-labelledby="pageHeader"
     aria-describedby="contactsCardTable"
   >
-    <page-header id="pageHeader" class="mb-3">
-      {{ $t('お問い合わせ先一覧') }}
-    </page-header>
+    <page-header id="pageHeader" :title="$t('お問い合わせ先一覧')" />
     <div class="Contacts-Card">
       <table
         id="contactsCardTable"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,22 +1,38 @@
 <template>
   <div v-scroll="onScroll">
+    <page-header
+      :icon-path="headerItem.iconPath"
+      :title="headerItem.title"
+      :updated-at="lastUpdateAsString"
+    />
     <site-top-upper />
     <lazy-cards-tab v-if="$vuetify.breakpoint.smAndUp || showCardsTab" />
   </div>
 </template>
 
 <script lang="ts">
+import { mdiChartTimelineVariant } from '@mdi/js'
 import Vue from 'vue'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import { MetaInfo } from 'vue-meta'
 
+import PageHeader from '@/components/PageHeader.vue'
+import { Data as IData } from '@/libraries/auto_generated/data_converter/convertData'
+
 type Data = {
+  headerItem: {
+    iconPath: string
+    title: string
+  }
   showCardsTab: boolean
 }
 type Methods = {
   onScroll: () => void
 }
-type Computed = {}
+type Computed = {
+  lastUpdateAsString: string
+  data: IData
+}
 type Props = {}
 
 const options: ThisTypedComponentOptionsWithRecordProps<
@@ -26,14 +42,29 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   Computed,
   Props
 > = {
+  components: {
+    PageHeader,
+  },
   data() {
     return {
+      headerItem: {
+        iconPath: mdiChartTimelineVariant,
+        title: this.$t('市内の最新感染動向') as string,
+      },
       showCardsTab: false,
     }
   },
   methods: {
     onScroll() {
       this.showCardsTab = true
+    },
+  },
+  computed: {
+    lastUpdateAsString() {
+      return this.data.lastUpdate
+    },
+    data() {
+      return this.$store.state.data
     },
   },
   head(): MetaInfo {

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="Worker">
-    <page-header class="mb-3">
-      {{ $t('企業の皆様・はたらく皆様へ') }}
-    </page-header>
+    <page-header :title="$t('企業の皆様・はたらく皆様へ')" />
     <static-card>
       <h3>
         <app-link


### PR DESCRIPTION
<!-- developmentへのPRに必ず変更してください。（初期は、mainです。） -->
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #126 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- トップページにおいて components/PageHeader.vue は components/SiteTopUpper.vue から参照されているが，pages/**.vue（pages/index.vue以外）と同様に pages/index.vue から参照できるようにする
  - ページ最上部に表示される header を pages/index.vue 内で定義できるようにする
  - components/SiteTopUpper.vue で定義している最終更新日時および翻訳に関する注釈を，component の props として定義できるようにする
  - pages/**.vue（pages/index.vue以外）でも翻訳に関する注釈を表示できるようにした（実際，翻訳ができていない箇所があるので表示することが望ましい）
- pages/index.vue では要素間の間隔が変更前と同じになるように CSS を調整した

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
